### PR TITLE
Remove duplicated and archived packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,17 +1,5 @@
 [
     {
-        "package": "riem",
-        "url": "https://github.com/ropensci/riem"
-    },
-    {
-        "package": "tinkr",
-        "url": "https://github.com/ropensci/tinkr"
-    },
-    {
-        "package": "rtimicropem",
-        "url": "https://github.com/ropensci/rtimicropem"
-    },
-    {
         "package": "goodpress",
         "url": "https://github.com/maelle/goodpress"
     },


### PR DESCRIPTION
The new dashboard now automatically shows packages that you maintain from other universes, e.g. ropensci. Therefore you can remove these duplicates from your personal universe.